### PR TITLE
feat: Implement repo sharing feature

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -58,3 +58,8 @@ input::-ms-clear {
         text-wrap: balance;
     }
 }
+
+#no-scroll {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+}

--- a/app/repo/page.tsx
+++ b/app/repo/page.tsx
@@ -62,7 +62,10 @@ export default function Page() {
         setErrorMsg('');
         const localRepo = loadRepoFromLocalStorage();
 
-        if (localRepo && localStorage.getItem(shared.keys.FORCE_UPDATE) != 'true') {
+        if (
+            localRepo &&
+            localStorage.getItem(shared.keys.FORCE_UPDATE) != 'true'
+        ) {
             setRepo(localRepo);
             setLoading(false);
             return;
@@ -78,7 +81,7 @@ export default function Page() {
         try {
             const refreshToken = getCookie(shared.keys.REFRESH_TOKEN);
             let accessToken = getCookie(shared.keys.ACCESS_TOKEN);
-            
+
             if (!accessToken) {
                 const { data: tokenData } = await axios.get(
                     `${SERVER_URL}/auth/refreshToken/${userID}`,
@@ -86,14 +89,14 @@ export default function Page() {
                         headers: { Authorization: `Bearer ${refreshToken}` },
                     }
                 );
-    
+
                 accessToken = tokenData.payload['access_token'];
                 setCookie(shared.keys.ACCESS_TOKEN, accessToken, {
                     maxAge: 20 * 60,
                     sameSite: 'strict',
                 }); // 20 mins
             }
-            
+
             const { data: repoData } = await axios.get(
                 `${SERVER_URL}/users/${userID}/repo/${repoID}`,
                 {
@@ -141,7 +144,9 @@ export default function Page() {
                         </section>
                     ) : errorMsg ? (
                         <section className="w-full grid place-items-center mt-8">
-                            <h3 className="text-neutral-300 text-xl">{errorMsg}</h3>
+                            <h3 className="text-neutral-300 text-xl">
+                                {errorMsg}
+                            </h3>
                         </section>
                     ) : (
                         repo && (
@@ -154,7 +159,10 @@ export default function Page() {
                                         {repo.description}
                                     </p>
                                 </div>
-                                <RepoViewLayout files={repo.files} />
+                                <RepoViewLayout
+                                    files={repo.files}
+                                    repoID={repo.id}
+                                />
                             </main>
                         )
                     )}

--- a/app/repo/page.tsx
+++ b/app/repo/page.tsx
@@ -160,8 +160,9 @@ export default function Page() {
                                     </p>
                                 </div>
                                 <RepoViewLayout
-                                    files={repo.files}
                                     repoID={repo.id}
+                                    isPublic={repo.isPublic}
+                                    files={repo.files}
                                 />
                             </main>
                         )

--- a/app/share/page.tsx
+++ b/app/share/page.tsx
@@ -56,12 +56,13 @@ export default function Page() {
         } catch (err) {
             const thisError = err as AxiosError;
             console.error('An error occurred.', err);
+            const serverErr = thisError.response?.data as ServerResponse;
 
             thisError.code == 'ERR_NETWORK'
                 ? showErrorState(
                       "We're having trouble connecting right now."
                   )
-                : showErrorState('This repo does not exist.');
+                : showErrorState(serverErr.message ?? 'An error occurred.');
         } finally {
             setIsLoading(false);
         }

--- a/app/share/page.tsx
+++ b/app/share/page.tsx
@@ -56,13 +56,12 @@ export default function Page() {
         } catch (err) {
             const thisError = err as AxiosError;
             console.error('An error occurred.', err);
-            const serverErr = thisError.response?.data as ServerResponse;
 
             thisError.code == 'ERR_NETWORK'
                 ? showErrorState(
                       "We're having trouble connecting right now."
                   )
-                : showErrorState(serverErr.message ?? 'An error occurred.');
+                : showErrorState('This repo does not exist.');
         } finally {
             setIsLoading(false);
         }

--- a/app/share/page.tsx
+++ b/app/share/page.tsx
@@ -1,0 +1,133 @@
+/**
+ *  2024 - NoteRepo Engineering, Open Source Software
+ *  This file is part of the source code which is available online.
+ *      - GitHub: https://github.com/NoteRepoLabs/noterepo-web-client
+ *      - LICENSE: MIT
+ */
+
+'use client';
+
+import FileIcon from '@/components/ui/FileIcon';
+import Footer from '@/components/ui/Footer';
+import SpinnerText from '@/components/ui/SpinnerText';
+import { SERVER_URL } from '@/config/constants';
+import NetworkConfig from '@/config/network';
+import Repo from '@/types/repoTypes';
+import ServerResponse from '@/types/serverTypes';
+import axios, { AxiosError } from 'axios';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+/**
+ * Responsible for listing shared public repositories
+ */
+export default function Page() {
+    const [isLoading, setIsLoading] = useState(true);
+    const [errorMsg, setErrorMsg] = useState('');
+    const [repo, setRepo] = useState<Repo>();
+    const [numberOfFiles, setNumberOfFiles] = useState(0);
+    const searchParams = useSearchParams();
+
+    // Error related state
+    const showErrorState = (msg: string) => {
+        setErrorMsg(msg);
+    };
+
+    // Responsible for fetching repositories with this id
+    const onLoad = async () => {
+        setErrorMsg('');
+        const repoID = searchParams.get('id');
+
+        // invalid page state
+        if (!repoID) {
+            showErrorState('Oops, this link is broken.');
+            return;
+        }
+
+        try {
+            const { data: fetchedData } = await axios.get(
+                `${SERVER_URL}/users/repo/${repoID}/share`,
+                NetworkConfig
+            );
+            const payload = fetchedData['payload'];
+
+            setNumberOfFiles(payload['files'].length);
+            setRepo(payload);
+        } catch (err) {
+            const thisError = err as AxiosError;
+            console.error('An error occurred.', err);
+            const serverErr = thisError.response?.data as ServerResponse;
+
+            thisError.code == 'ERR_NETWORK'
+                ? showErrorState(
+                      "We're having trouble connecting right now."
+                  )
+                : showErrorState(serverErr.message ?? 'An error occurred.');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        onLoad();
+    }, []);
+
+    return (
+        <section className="flex flex-col h-screen">
+            <section className="mt-8 w-full max-w-3xl mx-auto flex-grow">
+                {/* SPINNER */}
+                {isLoading && <SpinnerText text="We're getting the files..." />}
+
+                {/* ERROR MSG */}
+                {errorMsg && (
+                    <h2 className="w-full text-center mt-8 text-vibrant-red text-xl">
+                        {errorMsg}
+                    </h2>
+                )}
+
+                {/* METADATA + FILES */}
+                {!isLoading && !errorMsg && numberOfFiles != 0 && repo && (
+                    <main className="mt-6 w-full md:grid md:grid-cols-4 flex flex-col">
+                        <section className="flex flex-col items-center gap-2 mb-4">
+                            <h4 className="text-xs font-bold dark:text-neutral-500 mb-4">
+                                VIEWING SHARED REPO
+                            </h4>
+                            <h2 className="font-bold text-3xl">{repo.name}</h2>
+                            <p className="text-neutral-300">
+                                {repo.description}
+                            </p>
+                        </section>
+                        <section className="col-span-3 w-full p-4 overflow-hidden">
+                            <h2 className="text-2xl font-bold mb-4">
+                                {numberOfFiles} File
+                                {numberOfFiles == 1 ? '' : 's'} Here
+                            </h2>
+                            {numberOfFiles == 0 && (
+                                <p className="my-2 text-neutral-300">
+                                    No Files Uploaded yet.
+                                </p>
+                            )}
+                            <ul className="my-2 grid grid-cols-1 md:grid-cols-2 gap-4 w-full">
+                                {numberOfFiles != 0 &&
+                                    repo.files.map((file) => (
+                                        <li
+                                            key={file.id}
+                                            className="w-full text-neutral-300 col-span-1"
+                                        >
+                                            <div className="w-full">
+                                                <FileIcon
+                                                    filename={file.name}
+                                                    link={file.urlLink}
+                                                />
+                                            </div>
+                                        </li>
+                                    ))}
+                            </ul>
+                        </section>
+                    </main>
+                )}
+            </section>
+            <Footer />
+        </section>
+    );
+}

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -278,7 +278,7 @@ export default function DashboardView(props: DashboardProps) {
                         </div>
                     )}
 
-                    <section className="px-4 mt-8 w-full">
+                    <section className="px-4 mt-8 mb-4 w-full">
                         {!loading &&
                         !errorMsg &&
                         repos.length != 0 &&

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -251,7 +251,7 @@ export default function DashboardView(props: DashboardProps) {
 
                     {loading && (
                         <div className="flex justify-center items-start px-4">
-                            <SpinnerText text="Fetching your repos, just a moment..." />
+                            <SpinnerText text="Just a moment..." />
                         </div>
                     )}
 

--- a/components/repo/CreateRepoDialog.tsx
+++ b/components/repo/CreateRepoDialog.tsx
@@ -8,21 +8,21 @@
 'use client';
 
 import spinningAnimation from '@/animated/spinner.json';
-import { ChangeEvent, useState } from 'react';
-import InputField from '../ui/InputField';
-import FilledButton from '../ui/FilledButton';
-import { CloseCircle } from 'iconsax-react';
-import Toggle from '../ui/Toggle';
-import ErrorText from '../ui/ErrorText';
-import { useMutation } from '@tanstack/react-query';
-import axios from 'axios';
 import { SERVER_URL } from '@/config/constants';
 import NetworkConfig from '@/config/network';
+import shared from '@/shared/constants';
 import ServerResponse from '@/types/serverTypes';
+import { useMutation } from '@tanstack/react-query';
+import axios from 'axios';
 import { getCookie, setCookie } from 'cookies-next';
 import Lottie from 'lottie-react';
-import shared from '@/shared/constants';
+import { ChangeEvent, useState } from 'react';
+import CloseCircleIcon from '../ui/CloseCircleIcon';
+import ErrorText from '../ui/ErrorText';
+import FilledButton from '../ui/FilledButton';
+import InputField from '../ui/InputField';
 import Modal from '../ui/Modal';
+import Toggle from '../ui/Toggle';
 
 /* Create Repo Dialog Props */
 interface CreateRepoDialogProps {
@@ -166,12 +166,7 @@ export default function CreateRepoDialog(props: CreateRepoDialogProps) {
 
     return (
         <Modal>
-            <CloseCircle
-                size="24"
-                variant="Bold"
-                className="text-neutral-300 cursor-pointer absolute top-2 left-2 transition-colors hover:text-neutral-500 dark:hover:text-neutral-100"
-                onClick={props.onClick}
-            />
+            <CloseCircleIcon onClick={props.onClick} />
             <h3 className="text-2xl font-bold text-center dark:text-neutral-100 text-neutral-700">
                 Create Your Repo
             </h3>

--- a/components/repo/RepoViewLayout.tsx
+++ b/components/repo/RepoViewLayout.tsx
@@ -25,6 +25,7 @@ import UploadingFileDialog from './UploadingFileDialog';
 
 interface RepoViewLayoutProps {
     files: RepoFile[];
+    isPublic: boolean;
     repoID: string;
 }
 
@@ -261,11 +262,14 @@ export default function RepoViewLayout(props: RepoViewLayoutProps) {
                             icon={<Save2 size={24} />}
                             onClick={() => {}}
                         />
-                        <TextButton
+                        {/* ONLY PUBLIC REPOS CAN BE SHARED */}
+                        {props.isPublic && (
+                            <TextButton
                             text="Share"
                             icon={<Link1 size={24} />}
                             onClick={() => setShowShareRepoDialog(true)}
                         />
+                        )}
                         <TextButton
                             text="Delete"
                             icon={<Trash size={24} />}

--- a/components/repo/RepoViewLayout.tsx
+++ b/components/repo/RepoViewLayout.tsx
@@ -165,6 +165,12 @@ export default function RepoViewLayout(props: RepoViewLayoutProps) {
         }
     };
 
+    /**
+     * Handles selecting a file from the user's computer. Checks for file limit
+     * constraints and if passing, sends it to the server.
+     * @param ev Event
+     * @returns nothing
+     */
     const handleFileChange: React.ChangeEventHandler<HTMLInputElement> = (
         ev
     ) => {
@@ -219,6 +225,7 @@ export default function RepoViewLayout(props: RepoViewLayoutProps) {
                 />
             )}
 
+            {/* FILE LIST */}
             <main className="mt-6 w-full md:grid md:grid-cols-4 flex flex-col">
                 <section className="col-span-3 w-full p-4 overflow-hidden">
                     <h2 className="text-2xl font-bold mb-4">
@@ -247,6 +254,7 @@ export default function RepoViewLayout(props: RepoViewLayoutProps) {
                     </ul>
                 </section>
 
+                {/* SIDEBAR */}
                 <section className="border border-highlight md:col-span-1 p-4 dark:bg-mod-700 m-2 md:m-0 rounded-lg md:h-[200px] max-h-[200px]">
                     <h3 className="text-sm font-bold md:text-center mb-2">
                         ACTIONS

--- a/components/repo/RepoViewLayout.tsx
+++ b/components/repo/RepoViewLayout.tsx
@@ -247,7 +247,7 @@ export default function RepoViewLayout(props: RepoViewLayoutProps) {
                     </ul>
                 </section>
 
-                <section className="border border-highlight md:col-span-1 p-4 dark:bg-mod-700 m-2 md:m-0 rounded-lg h-[200px] max-h-[200px]">
+                <section className="border border-highlight md:col-span-1 p-4 dark:bg-mod-700 m-2 md:m-0 rounded-lg md:h-[200px] max-h-[200px]">
                     <h3 className="text-sm font-bold md:text-center mb-2">
                         ACTIONS
                     </h3>

--- a/components/repo/RepoViewLayout.tsx
+++ b/components/repo/RepoViewLayout.tsx
@@ -5,28 +5,23 @@
  *      - LICENSE: MIT
  */
 
-import { Save2, Link1, Trash } from 'iconsax-react';
-import TextButton from '../ui/TextButton';
-import FileUploadButton from '../ui/FileUploadButton';
-import { useRef, useState } from 'react';
-import { getCookie, setCookie } from 'cookies-next';
-import axios from 'axios';
 import { MEGABYTE, SERVER_URL } from '@/config/constants';
-import { useSearchParams } from 'next/navigation';
-import UploadingFileDialog from './UploadingFileDialog';
+import fetchRepos from '@/queries/fetchRepos';
+import shared from '@/shared/constants';
 import { RepoFile } from '@/types/repoTypes';
-import { File02Icon } from 'hugeicons-react';
+import axios from 'axios';
+import { getCookie, setCookie } from 'cookies-next';
+import { Link1, Save2, Trash } from 'iconsax-react';
+import { useSearchParams } from 'next/navigation';
+import { useRef, useState } from 'react';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-import { truncateText } from '@/util/text';
-import shared from '@/shared/constants';
 import FileIcon from '../ui/FileIcon';
-import { useMutation } from '@tanstack/react-query';
-import NetworkConfig from '@/config/network';
-import { ServerResponse } from 'http';
+import FileUploadButton from '../ui/FileUploadButton';
+import TextButton from '../ui/TextButton';
 import DeleteRepoDialog from './DeleteRepoDialog';
-import fetchRepos from '@/queries/fetchRepos';
-import Footer from '../ui/Footer';
+import ShareRepoDialog from './ShareRepoDialog';
+import UploadingFileDialog from './UploadingFileDialog';
 
 interface RepoViewLayoutProps {
     files: RepoFile[];
@@ -46,6 +41,7 @@ export default function RepoViewLayout(props: RepoViewLayoutProps) {
 
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
     const [showUploadingDialog, setShowUploadingDialog] = useState(false);
+    const [showShareRepoDialog, setShowShareRepoDialog] = useState(false);
     const [uploadProgress, setUploadProgress] = useState(0);
 
     /**
@@ -213,6 +209,11 @@ export default function RepoViewLayout(props: RepoViewLayoutProps) {
                 <UploadingFileDialog progress={uploadProgress} />
             )}
 
+            {/* SHARE REPO DIALOG */}
+            {showShareRepoDialog && (
+                <ShareRepoDialog onClick={() => setShowShareRepoDialog(false)} />
+            )}
+
             <main className="mt-6 w-full md:grid md:grid-cols-4 flex flex-col">
                 <section className="col-span-3 w-full p-4 overflow-hidden">
                     <h2 className="text-2xl font-bold mb-4">
@@ -259,7 +260,7 @@ export default function RepoViewLayout(props: RepoViewLayoutProps) {
                         <TextButton
                             text="Share"
                             icon={<Link1 size={24} />}
-                            onClick={() => {}}
+                            onClick={() => setShowShareRepoDialog(true)}
                         />
                         <TextButton
                             text="Delete"

--- a/components/repo/RepoViewLayout.tsx
+++ b/components/repo/RepoViewLayout.tsx
@@ -25,6 +25,7 @@ import UploadingFileDialog from './UploadingFileDialog';
 
 interface RepoViewLayoutProps {
     files: RepoFile[];
+    repoID: string;
 }
 
 const toastConfig = {
@@ -211,7 +212,10 @@ export default function RepoViewLayout(props: RepoViewLayoutProps) {
 
             {/* SHARE REPO DIALOG */}
             {showShareRepoDialog && (
-                <ShareRepoDialog onClick={() => setShowShareRepoDialog(false)} />
+                <ShareRepoDialog
+                    onClick={() => setShowShareRepoDialog(false)}
+                    repoID={props.repoID}
+                />
             )}
 
             <main className="mt-6 w-full md:grid md:grid-cols-4 flex flex-col">

--- a/components/repo/ShareRepoDialog.tsx
+++ b/components/repo/ShareRepoDialog.tsx
@@ -1,0 +1,33 @@
+/**
+ *  2024 - NoteRepo Engineering, Open Source Software
+ *  This file is part of the source code which is available online.
+ *      - GitHub: https://github.com/NoteRepoLabs/noterepo-web-client
+ *      - LICENSE: MIT
+ */
+
+'use client';
+
+import CloseCircleIcon from '../ui/CloseCircleIcon';
+import Modal from '../ui/Modal';
+
+interface ShareRepoDialogProps {
+    onClick: () => void;
+}
+
+/* Delete Repo Dialog Component */
+export default function ShareRepoDialog(props: ShareRepoDialogProps) {
+    return (
+        <>
+            <Modal>
+                <CloseCircleIcon onClick={props.onClick} />
+                <h3 className="text-2xl font-bold text-center dark:text-neutral-100 text-neutral-700">
+                    Share this Repo
+                </h3>
+                <p className="my-2 px-2 text-neutral-500 dark:text-neutral-300">
+                    Copy this link to share your repo with anyone! Note that
+                    anything you&apos;ve uploaded will be publicly viewable.
+                </p>
+            </Modal>
+        </>
+    );
+}

--- a/components/repo/ShareRepoDialog.tsx
+++ b/components/repo/ShareRepoDialog.tsx
@@ -32,10 +32,18 @@ export default function ShareRepoDialog(props: ShareRepoDialogProps) {
                     anything you&apos;ve uploaded will be publicly viewable.
                 </p>
                 <section className="flex gap-2 mt-4">
-                    <div className="w-[80%] dark:bg-neutral-700 max-w-md border-highlight border-2 rounded-md p-2 overflow-x-scroll !h-[48px] whitespace-nowrap" id="no-scroll">
+                    <div
+                        className="w-[80%] dark:bg-neutral-700 max-w-md border-highlight border-2 rounded-md p-2 overflow-x-scroll !h-[48px] whitespace-nowrap"
+                        id="no-scroll"
+                    >
                         <span>{sharingLink}</span>
                     </div>
-                    <button className="flex-grow">
+                    <button
+                        className="flex-grow bg-vibrant-green rounded-lg text-neutral-900"
+                        onClick={() => {
+                            navigator.clipboard.writeText(sharingLink);
+                        }}
+                    >
                         <span>Copy</span>
                     </button>
                 </section>

--- a/components/repo/ShareRepoDialog.tsx
+++ b/components/repo/ShareRepoDialog.tsx
@@ -39,7 +39,7 @@ export default function ShareRepoDialog(props: ShareRepoDialogProps) {
                         <span>{sharingLink}</span>
                     </div>
                     <button
-                        className="flex-grow bg-vibrant-green rounded-lg text-neutral-900"
+                        className="flex-grow bg-vibrant-green rounded-lg text-neutral-900 font-bold"
                         onClick={() => {
                             navigator.clipboard.writeText(sharingLink);
                         }}

--- a/components/repo/ShareRepoDialog.tsx
+++ b/components/repo/ShareRepoDialog.tsx
@@ -8,6 +8,7 @@
 'use client';
 
 import META from '@/shared/meta';
+import { useState } from 'react';
 import CloseCircleIcon from '../ui/CloseCircleIcon';
 import Modal from '../ui/Modal';
 
@@ -19,6 +20,20 @@ interface ShareRepoDialogProps {
 /* Delete Repo Dialog Component */
 export default function ShareRepoDialog(props: ShareRepoDialogProps) {
     const sharingLink = `${META.baseURL}/share?id=${props.repoID}`;
+    const [showCopiedText, setShowCopiedText] = useState(false);
+
+    // Write to the clipboard using the navigator
+    const handleCopyEvent = () => {
+        navigator.clipboard.writeText(sharingLink);
+        setShowCopiedText(true);
+        setTimeout(() => {
+            setShowCopiedText(false);
+            // close modal after copying?
+            // setTimeout(() => {
+            //     props.onClick();
+            // }, 500);
+        }, 500);
+    };
 
     return (
         <>
@@ -31,22 +46,25 @@ export default function ShareRepoDialog(props: ShareRepoDialogProps) {
                     Copy this link to share your repo with anyone! Note that
                     anything you&apos;ve uploaded will be publicly viewable.
                 </p>
-                <section className="flex gap-2 mt-4">
+                <section className="flex gap-2 mt-4 px-2 max-w-md">
                     <div
-                        className="w-[80%] dark:bg-neutral-700 max-w-md border-highlight border-2 rounded-md p-2 overflow-x-scroll !h-[48px] whitespace-nowrap"
+                        className="w-[80%] dark:bg-neutral-700 max-w-md border-highlight border-2 rounded-md p-2 overflow-x-scroll !h-[44px] whitespace-nowrap"
                         id="no-scroll"
                     >
                         <span>{sharingLink}</span>
                     </div>
                     <button
-                        className="flex-grow bg-vibrant-green rounded-lg text-neutral-900 font-bold"
-                        onClick={() => {
-                            navigator.clipboard.writeText(sharingLink);
-                        }}
+                        className="flex-grow bg-vibrant-green rounded-lg text-neutral-900 font-bold hover:opacity-80 transition-all active:scale-95"
+                        onClick={handleCopyEvent}
                     >
                         <span>Copy</span>
                     </button>
                 </section>
+                {showCopiedText && (
+                    <h4 className="text-vibrant-green font-bold text-sm mt-2">
+                        Copied!
+                    </h4>
+                )}
             </Modal>
         </>
     );

--- a/components/repo/ShareRepoDialog.tsx
+++ b/components/repo/ShareRepoDialog.tsx
@@ -31,8 +31,8 @@ export default function ShareRepoDialog(props: ShareRepoDialogProps) {
                     Copy this link to share your repo with anyone! Note that
                     anything you&apos;ve uploaded will be publicly viewable.
                 </p>
-                <section className="flex gap-2">
-                    <div className="w-[90%] max-w-[90%]">
+                <section className="flex gap-2 mt-4">
+                    <div className="w-[80%] dark:bg-neutral-700 max-w-md border-highlight border-2 rounded-md p-2 overflow-x-scroll !h-[48px] whitespace-nowrap" id="no-scroll">
                         <span>{sharingLink}</span>
                     </div>
                     <button className="flex-grow">

--- a/components/repo/ShareRepoDialog.tsx
+++ b/components/repo/ShareRepoDialog.tsx
@@ -7,15 +7,19 @@
 
 'use client';
 
+import META from '@/shared/meta';
 import CloseCircleIcon from '../ui/CloseCircleIcon';
 import Modal from '../ui/Modal';
 
 interface ShareRepoDialogProps {
     onClick: () => void;
+    repoID: string;
 }
 
 /* Delete Repo Dialog Component */
 export default function ShareRepoDialog(props: ShareRepoDialogProps) {
+    const sharingLink = `${META.baseURL}/share?id=${props.repoID}`;
+
     return (
         <>
             <Modal>
@@ -27,6 +31,14 @@ export default function ShareRepoDialog(props: ShareRepoDialogProps) {
                     Copy this link to share your repo with anyone! Note that
                     anything you&apos;ve uploaded will be publicly viewable.
                 </p>
+                <section className="flex gap-2">
+                    <div className="w-[90%] max-w-[90%]">
+                        <span>{sharingLink}</span>
+                    </div>
+                    <button className="flex-grow">
+                        <span>Copy</span>
+                    </button>
+                </section>
             </Modal>
         </>
     );

--- a/components/ui/CloseCircleIcon.tsx
+++ b/components/ui/CloseCircleIcon.tsx
@@ -1,0 +1,24 @@
+/**
+ *  2024 - NoteRepo Engineering, Open Source Software
+ *  This file is part of the source code which is available online.
+ *      - GitHub: https://github.com/NoteRepoLabs/noterepo-web-client
+ *      - LICENSE: MIT
+ */
+
+import { CloseCircle } from 'iconsax-react';
+
+interface CloseCircleProps {
+    onClick: () => void;
+}
+
+/* Close Circle Component */
+export default function CloseCircleIcon(props: CloseCircleProps) {
+    return (
+        <CloseCircle
+            size="24"
+            variant="Bold"
+            className="text-neutral-300 cursor-pointer absolute top-2 left-2 transition-colors hover:text-neutral-500 dark:hover:text-neutral-100"
+            onClick={props.onClick}
+        />
+    );
+}

--- a/components/ui/FileIcon.tsx
+++ b/components/ui/FileIcon.tsx
@@ -28,7 +28,7 @@ export default function FileIcon(props: FileIconProps) {
         if (name.includes('.ppt')) return `${base}/file-ppt.svg`;
         return `${base}/file-other.svg`;
     };
-    
+
     return (
         <>
             <section className="flex items-center gap-3">

--- a/components/ui/FileUploadButton.tsx
+++ b/components/ui/FileUploadButton.tsx
@@ -25,7 +25,7 @@ export default function FileUploadButton({
         <button
             onClick={onClick}
             disabled={disabled}
-            className="flex items-center gap-2 dark:hover:text-neutral-200  border-neutral-300 text-neutral-500 rounded-xl md:rounded-2xl dark:border-highlight dark:text-neutral-300  transition-all disabled:!opacity-70 active:scale-95"
+            className="flex items-center gap-2 dark:hover:text-neutral-200  border-neutral-300 text-neutral-500 rounded-xl md:rounded-2xl dark:border-highlight dark:text-neutral-300  transition-all disabled:!opacity-70 active:scale-[.98]"
         >
             <div>
                 <AddSquare size={24} />

--- a/components/ui/TextButton.tsx
+++ b/components/ui/TextButton.tsx
@@ -27,7 +27,7 @@ export default function TextButton({
         <button
             onClick={onClick}
             disabled={disabled}
-            className={`flex items-center gap-2 dark:hover:text-neutral-200  border-neutral-300 text-neutral-500 rounded-xl md:rounded-2xl dark:border-highlight dark:text-neutral-300  transition-all disabled:!opacity-70 active:scale-95 ${
+            className={`flex items-center gap-2 dark:hover:text-neutral-200  border-neutral-300 text-neutral-500 rounded-xl md:rounded-2xl dark:border-highlight dark:text-neutral-300  transition-all disabled:!opacity-70 active:scale-[.98] ${
                 danger ? `hover:!text-vibrant-red` : ''
             }`}
             style={{ ...styles }}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "npm run clean && next dev -p 3456",
+    "dev": "npm run clean && npx next dev -p 3456",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/shared/meta.ts
+++ b/shared/meta.ts
@@ -8,6 +8,7 @@
 
 // Metadata about the site
 const META = {
+    baseURL: 'https://noterepo.com.ng',
     github: 'https://github.com/NoteRepoLabs',
 };
 


### PR DESCRIPTION
# Introduction

This PR introduces changes to implement repo link-based sharing. The user is only allowed to share repos they've marked as public. 

## Changes

- UI fixes and improvements.
- Designed a new modal for generating and displaying sharing link.
- Created a new page, `/share` to display allowed repositories.
- Handled network edge cases and a few minor bug-fixes.